### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/322/95/85632295.geojson
+++ b/data/856/322/95/85632295.geojson
@@ -759,6 +759,11 @@
     ],
     "wof:country":"AW",
     "wof:country_alpha3":"ABW",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"bbfb7e7591ccf7813cd441ee194207c7",
     "wof:hierarchy":[
         {
@@ -777,7 +782,7 @@
         "eng",
         "spa"
     ],
-    "wof:lastmodified":1566603641,
+    "wof:lastmodified":1582314100,
     "wof:name":"Aruba",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/857/934/87/85793487.geojson
+++ b/data/857/934/87/85793487.geojson
@@ -73,6 +73,10 @@
         "wk:page":"Barcelona, Aruba"
     },
     "wof:country":"AW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"45d7719848e29f20a3f836c7cf9d7f5c",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566603641,
+    "wof:lastmodified":1582314100,
     "wof:name":"Barcelona",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/432/017/890432017.geojson
+++ b/data/890/432/017/890432017.geojson
@@ -278,6 +278,9 @@
     },
     "wof:country":"AW",
     "wof:created":1469051925,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"9e992731073eeb863a69843e8af71292",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         }
     ],
     "wof:id":890432017,
-    "wof:lastmodified":1566603646,
+    "wof:lastmodified":1582314100,
     "wof:name":"Oranjestad",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.