### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/170/955/421170955.geojson
+++ b/data/421/170/955/421170955.geojson
@@ -26,6 +26,9 @@
     "name:nld_x_preferred":[
         "Cashero"
     ],
+    "name:pap_x_preferred":[
+        "Cashero"
+    ],
     "name:swe_x_preferred":[
         "Cashero"
     ],
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421170955,
-    "wof:lastmodified":1566603645,
+    "wof:lastmodified":1690854308,
     "wof:name":"Cashero",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",

--- a/data/421/187/271/421187271.geojson
+++ b/data/421/187/271/421187271.geojson
@@ -23,6 +23,9 @@
     "name:nld_x_preferred":[
         "Fontein"
     ],
+    "name:pap_x_preferred":[
+        "Fontein"
+    ],
     "qs:gn_country":"AW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":3577209,
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421187271,
-    "wof:lastmodified":1566603645,
+    "wof:lastmodified":1690854307,
     "wof:name":"Fontein",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/199/779/421199779.geojson
+++ b/data/421/199/779/421199779.geojson
@@ -23,6 +23,9 @@
     "name:nld_x_preferred":[
         "Bringamosa"
     ],
+    "name:pap_x_preferred":[
+        "Bringamosa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421199779,
-    "wof:lastmodified":1566603645,
+    "wof:lastmodified":1690854307,
     "wof:name":"Bringamosa",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",

--- a/data/421/201/253/421201253.geojson
+++ b/data/421/201/253/421201253.geojson
@@ -29,6 +29,9 @@
     "name:nld_x_preferred":[
         "Babijn"
     ],
+    "name:pap_x_preferred":[
+        "Babijn"
+    ],
     "name:swe_x_preferred":[
         "Babijn"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421201253,
-    "wof:lastmodified":1566603645,
+    "wof:lastmodified":1690854307,
     "wof:name":"Babijn",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",

--- a/data/856/322/95/85632295.geojson
+++ b/data/856/322/95/85632295.geojson
@@ -39,6 +39,9 @@
     "name:amh_x_preferred":[
         "\u12a0\u1229\u1263"
     ],
+    "name:ang_x_preferred":[
+        "Aruba"
+    ],
     "name:ara_x_preferred":[
         "\u0623\u0631\u0648\u0628\u0627"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:ast_x_preferred":[
         "Aruba"
+    ],
+    "name:awa_x_preferred":[
+        "\u0905\u0930\u0942\u092c\u093e"
     ],
     "name:azb_x_preferred":[
         "\u0622\u0631\u0648\u0628\u0627"
@@ -136,6 +142,9 @@
         "Aruba"
     ],
     "name:deu_x_preferred":[
+        "Aruba"
+    ],
+    "name:diq_x_preferred":[
         "Aruba"
     ],
     "name:div_x_preferred":[
@@ -219,6 +228,9 @@
     ],
     "name:gsw_x_preferred":[
         "Aruba"
+    ],
+    "name:guc_x_preferred":[
+        "Aruuwa"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab0\u0ac1\u0aac\u0abe"
@@ -323,6 +335,9 @@
     "name:lao_x_preferred":[
         "\u0ead\u0eb2\u0ea5\u0eb9\u0e9a\u0eb2"
     ],
+    "name:lao_x_variant":[
+        "\u0ead\u0eb2\u0ea3\u0eb9\u0e9a\u0eb2"
+    ],
     "name:lat_x_preferred":[
         "Aruba"
     ],
@@ -344,6 +359,9 @@
     "name:lit_x_preferred":[
         "Aruba"
     ],
+    "name:lld_x_preferred":[
+        "Aruba"
+    ],
     "name:lmo_x_preferred":[
         "Aruba"
     ],
@@ -354,6 +372,9 @@
         "Aruba"
     ],
     "name:lug_x_preferred":[
+        "Aruba"
+    ],
+    "name:mad_x_preferred":[
         "Aruba"
     ],
     "name:mal_x_preferred":[
@@ -376,6 +397,9 @@
     ],
     "name:mlt_x_preferred":[
         "Aruba"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabd4\uabe8\uabd5\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u0410\u0440\u0443\u0431\u0430"
@@ -478,6 +502,9 @@
     ],
     "name:sgs_x_preferred":[
         "Aruba"
+    ],
+    "name:shn_x_preferred":[
+        "\u1022\u1083\u1087\u101b\u1030\u1038\u1015\u1083\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0d85\u0dbb\u0dd4\u0db6\u0dcf\u0dc0"
@@ -589,6 +616,9 @@
     ],
     "name:yue_x_preferred":[
         "\u963f\u9b6f\u5df4\u5cf6"
+    ],
+    "name:zea_x_preferred":[
+        "Aruba"
     ],
     "name:zho_cn_x_preferred":[
         "\u963f\u9c81\u5df4"
@@ -866,7 +896,7 @@
         "eng",
         "spa"
     ],
-    "wof:lastmodified":1617827371,
+    "wof:lastmodified":1690854307,
     "wof:name":"Aruba",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/432/017/890432017.geojson
+++ b/data/890/432/017/890432017.geojson
@@ -30,6 +30,9 @@
     "name:arg_x_preferred":[
         "Oranjestad"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0631\u0646\u062c\u0633\u062a\u0627\u062f"
+    ],
     "name:ast_x_preferred":[
         "Oranjestad"
     ],
@@ -43,7 +46,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d\u044c\u0435\u0441\u0442\u0430\u0434"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d'\u0435\u0441\u0442\u0430\u0434"
+        "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d'\u0435\u0441\u0442\u0430\u0434",
+        "\u0410\u0440\u0430\u043d\u044c\u0435\u0441\u0442\u0430\u0434"
     ],
     "name:ben_x_preferred":[
         "\u0993\u09b0\u09be\u099e\u09cd\u099c\u09c7\u09b8\u09cd\u09a4\u09be\u09a6"
@@ -105,6 +109,9 @@
     "name:fry_x_preferred":[
         "Oranjest\u00ead"
     ],
+    "name:gle_x_preferred":[
+        "Oranjestad"
+    ],
     "name:glg_x_preferred":[
         "Oranjestad"
     ],
@@ -126,6 +133,9 @@
     "name:ind_x_preferred":[
         "Oranjestad"
     ],
+    "name:isl_x_preferred":[
+        "Oranjestad"
+    ],
     "name:ita_x_preferred":[
         "Oranjestad"
     ],
@@ -140,6 +150,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc624\ub77c\ub15c\uc2a4\ud0c0\ud2b8"
+    ],
+    "name:lat_x_preferred":[
+        "Auriacopolis"
     ],
     "name:lav_x_preferred":[
         "Oranjestade"
@@ -213,7 +226,16 @@
     "name:slk_x_preferred":[
         "Oranjestad"
     ],
+    "name:slv_x_preferred":[
+        "Oranjestad"
+    ],
+    "name:smn_x_preferred":[
+        "Oranjestad"
+    ],
     "name:spa_x_preferred":[
+        "Oranjestad"
+    ],
+    "name:srd_x_preferred":[
         "Oranjestad"
     ],
     "name:srp_x_preferred":[
@@ -245,6 +267,9 @@
     ],
     "name:war_x_preferred":[
         "Oranjestad"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5965\u62c9\u6d85\u65af\u5854\u5fb7"
     ],
     "name:yor_x_preferred":[
         "Oranjestad"
@@ -299,7 +324,7 @@
         }
     ],
     "wof:id":890432017,
-    "wof:lastmodified":1636494850,
+    "wof:lastmodified":1690854308,
     "wof:name":"Oranjestad",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",

--- a/data/890/434/933/890434933.geojson
+++ b/data/890/434/933/890434933.geojson
@@ -31,6 +31,9 @@
     "name:nno_x_preferred":[
         "Angochi"
     ],
+    "name:pap_x_preferred":[
+        "Angochi"
+    ],
     "name:rus_x_preferred":[
         "\u0410\u043d\u0433\u043e\u043a\u0438"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890434933,
-    "wof:lastmodified":1566603646,
+    "wof:lastmodified":1690854308,
     "wof:name":"Angochi",
     "wof:parent_id":85667489,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.